### PR TITLE
Add Seek() method to nfs.File

### DIFF
--- a/nfs/file.go
+++ b/nfs/file.go
@@ -4,6 +4,7 @@
 package nfs
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -177,8 +178,36 @@ func (f *File) Close() error {
 	return nil
 }
 
+// Seek sets the offset for the next Read or Write to offset, interpreted according to whence.
+// This method implements Seeker interface.
+func (f *File) Seek(offset int64, whence int) (int64, error) {
+
+	// It would be nice to try to validate the offset here.
+	// However, as we're working with the shared file system, the file
+	// size might even change between NFSPROC3_GETATTR call and
+	// Seek() call, so don't even try to validate it.
+	// The only disadvantage of not knowing the current file size is that
+	// we cannot do io.SeekEnd seeks.
+	switch whence {
+	case io.SeekStart:
+		if offset < 0 {
+			return int64(f.curr), fmt.Errorf("offset cannot be negative")
+		}
+		f.curr = uint64(offset)
+		return int64(f.curr), nil
+	case io.SeekCurrent:
+		f.curr = uint64(int64(f.curr) + offset)
+		return int64(f.curr), nil
+	case io.SeekEnd:
+		return int64(f.curr), fmt.Errorf("SeekEnd is not supported yet")
+	default:
+		// This indicates serious programming error
+		panic("Invalid whence")
+	}
+}
+
 // OpenFile writes to an existing file or creates one
-func (v *Target) OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, error) {
+func (v *Target) OpenFile(path string, perm os.FileMode) (*File, error) {
 	_, fh, err := v.Lookup(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -201,7 +230,7 @@ func (v *Target) OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, er
 }
 
 // Open opens a file for reading
-func (v *Target) Open(path string) (io.ReadCloser, error) {
+func (v *Target) Open(path string) (*File, error) {
 	_, fh, err := v.Lookup(path)
 	if err != nil {
 		return nil, err

--- a/nfs/file.go
+++ b/nfs/file.go
@@ -4,7 +4,7 @@
 package nfs
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"os"
 
@@ -191,7 +191,7 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 	switch whence {
 	case io.SeekStart:
 		if offset < 0 {
-			return int64(f.curr), fmt.Errorf("offset cannot be negative")
+			return int64(f.curr), errors.New("offset cannot be negative")
 		}
 		f.curr = uint64(offset)
 		return int64(f.curr), nil
@@ -199,7 +199,7 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 		f.curr = uint64(int64(f.curr) + offset)
 		return int64(f.curr), nil
 	case io.SeekEnd:
-		return int64(f.curr), fmt.Errorf("SeekEnd is not supported yet")
+		return int64(f.curr), errors.New("SeekEnd is not supported yet")
 	default:
 		// This indicates serious programming error
 		panic("Invalid whence")

--- a/nfs/file.go
+++ b/nfs/file.go
@@ -202,7 +202,7 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 		return int64(f.curr), errors.New("SeekEnd is not supported yet")
 	default:
 		// This indicates serious programming error
-		panic("Invalid whence")
+		return int64(f.curr), errors.New("Invalid whence")
 	}
 }
 


### PR DESCRIPTION
Implement Seek() as required by io.Seeker() interface specification.
As there is no predefined interface that implements both Read(), Write(),
Seek() and Close(), return *nfs.File from Open() and OpenFile() calls
instead of io.* interfaces.
So now nfs.File implements even more interfaces, including io.ReadSeeker(), io.ReadWriteCloser()
and so on.