### PR TITLE
Depend on a version of go-xdr with working discriminated unions

### DIFF
--- a/nfs/xdr/decode.go
+++ b/nfs/xdr/decode.go
@@ -6,7 +6,7 @@ package xdr
 import (
 	"io"
 
-	xdr "github.com/davecgh/go-xdr/xdr2"
+	xdr "github.com/rasky/go-xdr/xdr2"
 )
 
 func Read(r io.Reader, val interface{}) error {

--- a/nfs/xdr/encode.go
+++ b/nfs/xdr/encode.go
@@ -6,7 +6,7 @@ package xdr
 import (
 	"io"
 
-	xdr "github.com/davecgh/go-xdr/xdr2"
+	xdr "github.com/rasky/go-xdr/xdr2"
 )
 
 func Write(w io.Writer, val interface{}) error {


### PR DESCRIPTION
Commit 7592fd7d851fefba0758fec6bfcf2f363f56d4da makes use of the `` `xdr:"union"` `` and `` `xdr:"unioncase=N"` `` annotations that were submitted in a pull request that has not been merged upstream to davecgh/go-xdr:

https://github.com/davecgh/go-xdr/pull/6

Without support for these annotations, the code is unable to parse a valid FSINFO reply.